### PR TITLE
Add link for individual planet bookings

### DIFF
--- a/app/views/planets/show.html.erb
+++ b/app/views/planets/show.html.erb
@@ -6,3 +6,5 @@
 <%= link_to planet_path(@planet), method: :delete, data: { confirm: "Charging the Death Star... Fire?" } do %>
   <i class="fas fa-bomb"></i> Exterminate
 <% end %>
+<%= link_to "Show this planet's bookings", planet_bookings_path(@planet, @booking) %>
+


### PR DESCRIPTION
We can discuss tomorrow how we want to actually display this, as the ability to view a planet's bookings depends on the current_user's id